### PR TITLE
Sparse conn

### DIFF
--- a/functions_matlab/calc_surface_connectivity.m
+++ b/functions_matlab/calc_surface_connectivity.m
@@ -12,23 +12,6 @@ function surface_connectivity = calc_surface_connectivity(surface)
 
 %%
 
-% num_vertices = size(surface.vertices, 1);
-% num_faces = size(surface.faces, 1);
-% 
-% surface_connectivity = zeros(num_vertices);
-% 
-% for face_ind = 1:num_faces
-%     face_interest = surface.faces(face_ind,:);
-%     
-%     surface_connectivity(face_interest(1), face_interest(2)) = 1;
-%     surface_connectivity(face_interest(1), face_interest(3)) = 1;
-%     surface_connectivity(face_interest(2), face_interest(3)) = 1;
-% end
-% 
-% surface_connectivity = surface_connectivity + surface_connectivity';
-% surface_connectivity(surface_connectivity>0) = 1;
-
-
 num_vertices = size(surface.vertices, 1);
 f = surface.faces;
 

--- a/functions_matlab/calc_surface_connectivity.m
+++ b/functions_matlab/calc_surface_connectivity.m
@@ -12,19 +12,31 @@ function surface_connectivity = calc_surface_connectivity(surface)
 
 %%
 
+% num_vertices = size(surface.vertices, 1);
+% num_faces = size(surface.faces, 1);
+% 
+% surface_connectivity = zeros(num_vertices);
+% 
+% for face_ind = 1:num_faces
+%     face_interest = surface.faces(face_ind,:);
+%     
+%     surface_connectivity(face_interest(1), face_interest(2)) = 1;
+%     surface_connectivity(face_interest(1), face_interest(3)) = 1;
+%     surface_connectivity(face_interest(2), face_interest(3)) = 1;
+% end
+% 
+% surface_connectivity = surface_connectivity + surface_connectivity';
+% surface_connectivity(surface_connectivity>0) = 1;
+
+
 num_vertices = size(surface.vertices, 1);
-num_faces = size(surface.faces, 1);
+f = surface.faces;
 
-surface_connectivity = zeros(num_vertices);
+temp = ...
+    sparse( ...
+        reshape(f           ,  [], 1), ...
+        reshape(f(:, [2 3 1]), [], 1), ...
+        true, num_vertices, num_vertices ...
+    );
 
-for face_ind = 1:num_faces
-    face_interest = surface.faces(face_ind,:);
-    
-    surface_connectivity(face_interest(1), face_interest(2)) = 1;
-    surface_connectivity(face_interest(1), face_interest(3)) = 1;
-    surface_connectivity(face_interest(2), face_interest(3)) = 1;
-end
-
-surface_connectivity = surface_connectivity + surface_connectivity';
-surface_connectivity(surface_connectivity>0) = 1;
-
+surface_connectivity = full(temp | temp'); % can replace with +full if desired

--- a/functions_matlab/calc_surface_connectivity.m
+++ b/functions_matlab/calc_surface_connectivity.m
@@ -13,18 +13,13 @@ function surface_connectivity = calc_surface_connectivity(surface)
 %%
 
 num_vertices = size(surface.vertices, 1);
-num_faces = size(surface.faces, 1);
+f = surface.faces;
 
-surface_connectivity = zeros(num_vertices);
+temp = ...
+    sparse( ...
+        reshape(f           ,  [], 1), ...
+        reshape(f(:, [2 3 1]), [], 1), ...
+        true, num_vertices, num_vertices ...
+    );
 
-for face_ind = 1:num_faces
-    face_interest = surface.faces(face_ind,:);
-    
-    surface_connectivity(face_interest(1), face_interest(2)) = 1;
-    surface_connectivity(face_interest(1), face_interest(3)) = 1;
-    surface_connectivity(face_interest(2), face_interest(3)) = 1;
-end
-
-surface_connectivity = surface_connectivity + surface_connectivity';
-surface_connectivity(surface_connectivity>0) = 1;
-
+surface_connectivity = full(temp | temp'); % can replace with +full if desired


### PR DESCRIPTION
speedup calc_surface_connectivity using sparse matrix generation (instead of manually adding each face)
around 10x faster when tested on fsLR-32k